### PR TITLE
Fixup EHR launch flow

### DIFF
--- a/sof_wrapper/auth/views.py
+++ b/sof_wrapper/auth/views.py
@@ -108,6 +108,8 @@ def auth_info():
     auth_info = session['auth_info']
 
     return {
+        'token_data': auth_info['token'],
+
         # from front-end launch-context.json
         "client_id": "6c12dff4-24e7-4475-a742-b08972c4ea27",
         "scope": "patient/*.read launch/patient",

--- a/sof_wrapper/auth/views.py
+++ b/sof_wrapper/auth/views.py
@@ -95,7 +95,7 @@ def authorize():
         launch_dest=current_app.config['LAUNCH_DEST'],
         querystring_params=urlencode({
             "iss": "https://launch.smarthealthit.org/v/r2/fhir",
-            "patient": "5c41cecf-cf81-434f-9da7-e24e5a99dbc2",
+            "patient": token['patient'],
         }),
     )
 
@@ -119,7 +119,7 @@ def auth_info():
         "fhirServiceUrl":"https://launch.smarthealthit.org/v/r2/fhir",
         "iss":"https://launch.smarthealthit.org/v/r2/fhir",
         "server":"https://launch.smarthealthit.org/v/r2/fhir",
-        "patientId":"5c41cecf-cf81-434f-9da7-e24e5a99dbc2",
+        "patientId":auth_info['token']['patient'],
     }
 
 

--- a/sof_wrapper/auth/views.py
+++ b/sof_wrapper/auth/views.py
@@ -42,7 +42,7 @@ def launch():
 
         # todo: try using iss
         #api_base_url=iss+'/',
-        #client_kwargs={'scope': 'user:email'},
+        client_kwargs={'scope': "patient/*.read launch/patient"},
     )
 
     # URL to pass (as QS param) to EHR Authz server


### PR DESCRIPTION
* Remove hard-coded patient ids
* Pass `launch` querystring param given by EHR:
>When using the EHR launchflow, this must match the launch value received from the EHR.

