### PR TITLE
Initial take at logging additional parameters in JSON format

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,13 @@ Read application logs
     docker-compose logs --follow
 
 
+Test
+----
+Without a ``setup.py`` to install, invoke as follows from the root directory to
+automatically include the current directory in ``PYTHONPATH``
+
+    python -m pytest tests
+
 License
 -------
 BSD

--- a/logging.ini
+++ b/logging.ini
@@ -1,0 +1,22 @@
+[loggers]
+keys=root
+
+[handlers]
+keys=consoleHandler
+
+[formatters]
+keys=json
+
+[logger_root]
+level=DEBUG
+handlers=consoleHandler
+
+[handler_consoleHandler]
+class=StreamHandler
+level=DEBUG
+formatter=json
+args=(sys.stdout,)
+
+[formatter_json]
+class=pythonjsonlogger.jsonlogger.JsonFormatter
+format=%(asctime)s %(name)s %(levelname)s %(message)s

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 authlib
 flask
+python-json-logger
 requests

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,6 @@
 authlib
 flask
+pytest
+python-jose[cryptography]
 python-json-logger
 requests

--- a/sof_wrapper/api/views.py
+++ b/sof_wrapper/api/views.py
@@ -1,4 +1,4 @@
-from flask import Blueprint
+from flask import Blueprint, current_app
 
 
 base_blueprint = Blueprint('base', __name__)
@@ -6,6 +6,8 @@ base_blueprint = Blueprint('base', __name__)
 
 @base_blueprint.route('/')
 def root():
+    current_app.logger.warn(
+        'example message', extra={'extra_i': 12, 'extra_j': 'whee'})
     return {'ok':True}
 
 @base_blueprint.after_request

--- a/sof_wrapper/app.py
+++ b/sof_wrapper/app.py
@@ -1,3 +1,4 @@
+from logging import config as logging_config
 from flask import Flask
 
 from sof_wrapper import auth, api
@@ -10,10 +11,16 @@ def create_app(testing=False, cli=False):
     app = Flask('sof_wrapper')
     app.config.from_object('sof_wrapper.config')
 
+    configure_logging(app)
     configure_extensions(app, cli)
     register_blueprints(app)
 
     return app
+
+
+def configure_logging(app):
+    app.logger  # must call to initialize prior to config or it'll replace
+    logging_config.fileConfig('logging.ini', disable_existing_loggers=False)
 
 
 def configure_extensions(app, cli):

--- a/sof_wrapper/auth/helpers.py
+++ b/sof_wrapper/auth/helpers.py
@@ -1,0 +1,8 @@
+from jose import jwt
+
+
+def extract_payload(token):
+    """Given JWT, extract the payload and return as dict"""
+    if not token:
+        return None
+    return jwt.get_unverified_claims(token)

--- a/sof_wrapper/auth/views.py
+++ b/sof_wrapper/auth/views.py
@@ -1,6 +1,4 @@
 from flask import Blueprint, current_app, redirect, request, url_for, session
-from urllib.parse import urlencode
-import base64
 import requests
 
 from sof_wrapper.extensions import oauth
@@ -11,14 +9,18 @@ blueprint = Blueprint('auth', __name__, url_prefix='/auth')
 
 def debugging_compliance_fix(session):
     def _fix(response):
-        current_app.logger.info('access_token request url: %s', response.request.url)
-        current_app.logger.info('access_token request headers: %s', response.request.headers)
-        current_app.logger.info('access_token request body: %s', response.request.body)
+        current_app.logger.debug(
+            'access_token request url: %s', response.request.url)
+        current_app.logger.debug(
+            'access_token request headers: %s', response.request.headers)
+        current_app.logger.debug(
+            'access_token request body: %s', response.request.body)
 
-
-        current_app.logger.info('access_token response: %s', response)
-        current_app.logger.info('access_token response.status_code: %s', response.status_code)
-        current_app.logger.info('access_token response.content: %s', response.content)
+        current_app.logger.debug('access_token response: %s', response)
+        current_app.logger.debug(
+            'access_token response.status_code: %s', response.status_code)
+        current_app.logger.debug(
+            'access_token response.content: %s', response.content)
 
         response.raise_for_status()
 
@@ -38,12 +40,11 @@ def launch():
 
     launch = request.args.get('launch')
     if launch:
-        # launch value recieved from EHR
+        # launch value received from EHR
         current_app.logger.debug('launch: %s', launch)
 
-
     # errors with r4 even if iss and aud params match
-    #iss = 'https://launch.smarthealthit.org/v/r2/fhir'
+    # iss = 'https://launch.smarthealthit.org/v/r2/fhir'
 
     # fetch conformance statement from /metadata
     ehr_metadata_url = '%s/metadata' % iss
@@ -65,7 +66,7 @@ def launch():
         authorize_url=authorize_url,
         compliance_fix=debugging_compliance_fix,
         # todo: try using iss
-        #api_base_url=iss+'/',
+        # api_base_url=iss+'/',
         client_kwargs={'scope': current_app.config['SOF_CLIENT_SCOPES']},
     )
     # work around back-end caching of dynamic config values
@@ -101,8 +102,8 @@ def authorize():
         }
         return error_details, 400
     # authlib persists OAuth client details via secure cookie
-    #if not '_sof_authlib_state_' in session:
-        #return 'authlib state cookie missing; restart auth flow', 400
+    # if not '_sof_authlib_state_' in session:
+        # return 'authlib state cookie missing; restart auth flow', 400
 
     # todo: define fetch_token function that requests JSON (Accept: application/json header)
     # https://github.com/lepture/authlib/blob/master/authlib/oauth2/client.py#L154
@@ -123,8 +124,6 @@ def authorize():
         'req': request.args,
         #'patient_data': response.json(),
     }
-
-
 
     frontend_url = current_app.config['LAUNCH_DEST']
 
@@ -151,19 +150,23 @@ def auth_info():
 
 @blueprint.route('/users/<int:user_id>')
 def users(user_id):
-    return {'ok':True}
+    return {'ok': True}
 
 
 @blueprint.before_request
 def before_request_func():
-    current_app.logger.info('before_request session: %s', session)
-    current_app.logger.info('before_request authlib state present: %s', '_sof_authlib_state_' in session)
+    current_app.logger.debug('before_request session: %s', session)
+    current_app.logger.debug(
+        'before_request authlib state present: %s',
+        '_sof_authlib_state_' in session)
 
 
 @blueprint.after_request
 def after_request_func(response):
-    current_app.logger.info('after_request session: %s', session)
-    current_app.logger.info('after_request authlib state present: %s', '_sof_authlib_state_' in session)
+    current_app.logger.debug('after_request session: %s', session)
+    current_app.logger.debug(
+        'after_request authlib state present: %s',
+        '_sof_authlib_state_' in session)
 
     # todo: make configurable
     origin = request.headers.get('Origin', '*')

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -1,0 +1,25 @@
+from pytest import fixture
+from sof_wrapper.auth.helpers import extract_payload
+
+
+@fixture
+def example_token():
+    return '.'.join((
+        'eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiJ9',
+        'eyJwcm9maWxlIjoiUHJhY3RpdGlvbmVyL1NNQVJULTEyMzQiLCJzdWIiOiI3NmQ1M2Zm'
+        'NmNjZDY5ZWEyN2YzMjM5MzgwYjMwMzliNGE4NzI5OTJmODE1MWViMzE4Y2UxODZlZDlm'
+        'MmYzMTNjIiwiaXNzIjoiaHR0cHM6Ly9zbWFydC1kZXYtc2FuZGJveC1sYXVuY2hlci5j'
+        'aXJnLndhc2hpbmd0b24uZWR1IiwiaWF0IjoxNTg4MDIwNDU3LCJleHAiOjE1ODgwMjQw'
+        'NTd9',
+        'PyWKOdkS1AUGF6R0s1RWkhLXF2rFKq9m-Xdw4LaJSHKchpDRVpZ_jlpv73D09F3pIRJn'
+        'Tq10EJDv34V0UNRiD53IVgdTS680p-kj5t1fpE66aOU-aLQHkaH0mdvGVdXKGHaidda2'
+        'Uq-QdoVT17RtKHeVzfKdEOMGbKPUDbKktgVw57JuTrUgtsOihsYKMu5j09J6ZB1K1deg'
+        'm2ppl_0DMhP_UJgbniOlgpIyR2QYLTS2Dz-DLsYmPr-anK8d_wVHdXqt3TCnCnYOww8o'
+        '6eBsFF_BtbWNO-CYTsnhQB_UKs1TNVrneVoTDGSLZPdcnK1ay23IiA2PTybPrFja6kdz'
+        'qQ'))
+
+
+def test_extract(example_token):
+    extracted = extract_payload(example_token)
+    assert 'profile' in extracted
+    assert extracted['profile'] == 'Practitioner/SMART-1234'


### PR DESCRIPTION
Initial add for `login` and `launch` events, includes JSON formatting of log entries including `user` and `subject` when applicable.

Extend scopes to pickup `id_token` as necessary for obtaining the `subject`:
```SOF_CLIENT_SCOPES=patient/*.read launch openid profile```
