### PR TITLE
Simplify PDMP & PHR Config

### DIFF
--- a/sof_wrapper/api/fhir.py
+++ b/sof_wrapper/api/fhir.py
@@ -7,9 +7,7 @@ blueprint = Blueprint('fhir', __name__, url_prefix='/v/r2/fhir/')
 
 @blueprint.route('/MedicationOrder')
 def medication_order():
-    pdmp_url = '{base_url}/v/r2/fhir/MedicationOrder'.format(
-        base_url=current_app.config['PDMP_URL'],
-    )
+    pdmp_url = current_app.config['PDMP_URL']
     response = requests.get(pdmp_url)
     response.raise_for_status()
     return response.json()

--- a/sof_wrapper/api/fhir.py
+++ b/sof_wrapper/api/fhir.py
@@ -17,15 +17,10 @@ def medication_order():
 
 @blueprint.route('/Observation')
 def observations():
-    phr_url = '{base_url}/Observation'.format(
-        base_url=current_app.config['PHR_URL'],
-    )
-    # todo: lookup from frontend with Patient details
-    phr_params = {'patient._id': '53b07006-f454-ea11-8241-0a0332b55c97'}
+    phr_url = current_app.config['PHR_URL']
 
     phr_observations = requests.get(
         url=phr_url,
-        params=phr_params,
         headers={
             'Authorization': 'Bearer %s' % current_app.config['PHR_TOKEN'],
             'Accept': 'application/json',


### PR DESCRIPTION
* Make entire PHR URL configurable
* Make entire PDMP URL configurable
eg:
```
# docker-compose.yaml
services:
  backend:
    environment:
      PHR_URL: 'https://dev.fhir.onerecord.com/Observation/d92adee0-9991-4a21-8c89-a74bd42a9798'
```