### PR TITLE
Detect headers applied by upstream proxy

### DIFF
--- a/sof_wrapper.env.default
+++ b/sof_wrapper.env.default
@@ -2,6 +2,9 @@
 SERVER_NAME=localtest.me:5000
 SECRET_KEY=
 
+# enable when served behind https
+# PREFERRED_URL_SCHEME=https
+
 SOF_CLIENT_ID=
 SOF_CLIENT_SECRET=
 #SOF_CLIENT_SCOPES=patient/*.read launch/patient

--- a/sof_wrapper/config.py
+++ b/sof_wrapper/config.py
@@ -7,6 +7,8 @@ import redis
 
 SERVER_NAME = os.getenv("SERVER_NAME")
 SECRET_KEY = os.getenv("SECRET_KEY")
+# URL scheme to use outside of request context
+PREFERRED_URL_SCHEME = os.getenv("PREFERRED_URL_SCHEME")
 
 SESSION_TYPE = os.getenv("SESSION_TYPE", 'redis')
 SESSION_REDIS = redis.from_url(os.getenv("SESSION_REDIS", "redis://127.0.0.1:6379"))


### PR DESCRIPTION
* Read `PREFERRED_URL_SCHEME` from env var
  * Sets URL scheme when no request context available
* Conditionally enable proxy detection when `PREFERRED_URL_SCHEME` set
