### PR TITLE
FHIR Router/Proxy

### DIFF
--- a/sof_wrapper/api/fhir.py
+++ b/sof_wrapper/api/fhir.py
@@ -1,4 +1,4 @@
-from flask import Blueprint, current_app, request, session
+from flask import Blueprint, current_app, request, session, g
 import requests
 import pickle
 
@@ -155,6 +155,7 @@ def get_redis_session_data(session_id):
 @blueprint.route('/fhir-router/', defaults={'relative_path': '', 'session_id': None})
 @blueprint.route('/fhir-router/<string:session_id>/<path:relative_path>')
 def route_fhir(relative_path, session_id):
+    g.session_id = session_id
     paths = relative_path.split('/')
     resource_name = paths.pop()
 

--- a/sof_wrapper/api/fhir.py
+++ b/sof_wrapper/api/fhir.py
@@ -160,6 +160,7 @@ def get_redis_session_data(session_id):
 @blueprint.route('/fhir-router/<string:session_id>/<path:relative_path>')
 def route_fhir(relative_path, session_id):
     g.session_id = session_id
+    current_app.logger.debug('received session_id as path parameter: %s', session_id)
     paths = relative_path.split('/')
     resource_name = paths.pop()
 

--- a/sof_wrapper/api/fhir.py
+++ b/sof_wrapper/api/fhir.py
@@ -96,7 +96,7 @@ def medication_requests():
         emr_med_requests(patient_id),
     )
 
-
+# TODO: refactor to "collate" API, like medication_requests()
 @blueprint.route(f'{r2prefix}/MedicationOrder')
 def medication_order():
     pdmp_url = '{base_url}/v/r2/fhir/MedicationOrder'.format(
@@ -164,6 +164,7 @@ def route_fhir(relative_path, session_id):
     resource_name = paths.pop()
 
     route_map = {
+        # TODO: refactor to "collate" API, like medication_requests()
         #'MedicationOrder': medication_order,
         'MedicationRequest': medication_requests
     }

--- a/sof_wrapper/api/fhir.py
+++ b/sof_wrapper/api/fhir.py
@@ -165,7 +165,7 @@ def route_fhir(relative_path, session_id):
 
     route_map = {
         #'MedicationOrder': medication_order,
-        #'MedicationRequest': medication_requests
+        'MedicationRequest': medication_requests
     }
 
 

--- a/sof_wrapper/api/fhir.py
+++ b/sof_wrapper/api/fhir.py
@@ -92,7 +92,9 @@ def medication_requests():
             f"eq{patient_fhir['birthDate']}")
 
     return collate_results(
-        pdmp_med_requests(**pdmp_args), emr_med_requests(patient_id))
+        pdmp_med_requests(**pdmp_args),
+        emr_med_requests(patient_id),
+    )
 
 
 @blueprint.route(f'{r2prefix}/MedicationOrder')

--- a/sof_wrapper/api/fhir.py
+++ b/sof_wrapper/api/fhir.py
@@ -145,6 +145,8 @@ def route_fhir(relative_path):
     resource_name = paths.pop()
 
     route_map = {
+        #'MedicationOrder': medication_order,
+        #'MedicationRequest': medication_requests
     }
 
 

--- a/sof_wrapper/api/fhir.py
+++ b/sof_wrapper/api/fhir.py
@@ -188,5 +188,6 @@ def route_fhir(relative_path, session_id):
 @blueprint.after_request
 def add_header(response):
     response.headers['Access-Control-Allow-Origin'] = '*'
+    response.headers['Access-Control-Allow-Headers'] = 'Authorization'
 
     return response

--- a/sof_wrapper/api/fhir.py
+++ b/sof_wrapper/api/fhir.py
@@ -153,7 +153,8 @@ def route_fhir(relative_path):
     if resource_name in route_map:
         return route_map[resource_name]()
 
-    upstream_fhir_base_url = session['iss']
+    # TODO: associate session vars correctly
+    upstream_fhir_base_url = session.get('iss', 'https://launch.smarthealthit.org/v/r4/fhir')
     upstream_fhir_url = '/'.join((upstream_fhir_base_url, relative_path))
     upstream_headers = {}
     if 'Authorization' in request.headers:

--- a/sof_wrapper/auth/views.py
+++ b/sof_wrapper/auth/views.py
@@ -176,7 +176,8 @@ def auth_info():
             "access_token": token_response['access_token'],
             "token_type": "Bearer",
         },
-        "fhirServiceUrl": iss,
+        "realFhirServiceUrl": iss,
+        "fhirServiceUrl": url_for('fhir.route_fhir', _external=True),
         # fallback to patient obtained from non-opaque (non-standard) launch token
         "patientId":token_response.get('patient', launch_token_patient),
     }

--- a/sof_wrapper/auth/views.py
+++ b/sof_wrapper/auth/views.py
@@ -168,6 +168,7 @@ def auth_info():
     token_response = session['token_response']
     iss = session['iss']
     launch_token_patient = session['launch_token_patient']
+    session_id = request.cookies.get(current_app.session_cookie_name)
     return {
         # debugging
         'token_data': token_response,
@@ -177,7 +178,12 @@ def auth_info():
             "token_type": "Bearer",
         },
         "realFhirServiceUrl": iss,
-        "fhirServiceUrl": url_for('fhir.route_fhir', _external=True),
+        "fhirServiceUrl": url_for(
+            'fhir.route_fhir',
+            session_id=session_id,
+            relative_path='',
+            _external=True
+        ),
         # fallback to patient obtained from non-opaque (non-standard) launch token
         "patientId":token_response.get('patient', launch_token_patient),
     }


### PR DESCRIPTION
* Add fake FHIR endpoint to intercept/route requests and associate session_id
* Lookup session data directly from redis with given session_id

#### Todo
- [ ] Add tests for checking querystring **and** path parameters are passed correctly through router endpoint
- [ ] Refactor `medication_orders()` collate API to match `medication_requests()` signature