### PR TITLE
Add redis service for GitHub CI

### DIFF
--- a/.github/workflows/test-build-deliver.yaml
+++ b/.github/workflows/test-build-deliver.yaml
@@ -6,7 +6,7 @@ on: [push]
 jobs:
   test:
     runs-on: ubuntu-latest
-
+    container: python:3.7
     # Service containers to run with `container-job`
     services:
       # Label used to access the service container
@@ -19,16 +19,10 @@ jobs:
           --health-interval 10s
           --health-timeout 5s
           --health-retries 5
-
     env:
       SESSION_REDIS: redis://redis:6379/0
     steps:
       - uses: actions/checkout@v1
-
-      - name: Set up Python 3.7
-        uses: actions/setup-python@v1
-        with:
-          python-version: 3.7
 
       - name: Install test runner
         run: python3 -m pip install tox

--- a/.github/workflows/test-build-deliver.yaml
+++ b/.github/workflows/test-build-deliver.yaml
@@ -6,6 +6,22 @@ on: [push]
 jobs:
   test:
     runs-on: ubuntu-latest
+
+    # Service containers to run with `container-job`
+    services:
+      # Label used to access the service container
+      redis:
+        # Docker Hub image
+        image: redis
+        # Set health checks to wait until redis has started
+        options: >-
+          --health-cmd "redis-cli ping"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
+    env:
+      SESSION_REDIS: redis://redis:6379/0
     steps:
       - uses: actions/checkout@v1
 
@@ -19,6 +35,7 @@ jobs:
 
       - name: Run tests
         run: tox
+
 
   build:
     # only build if tests pass

--- a/tox.ini
+++ b/tox.ini
@@ -13,9 +13,9 @@ setenv =
 passenv =
     FLASK_APP
     LANG
-    PERSISTENCE_DIR
     SECRET_KEY
     CI
+    *REDIS*
 changedir = tests
 commands =
     py.test \


### PR DESCRIPTION
* Use python docker image (`python:3.7`) instead of installing python on CI runner VM
* Add redis service
* Update tox passthrough environment variables
