### PR TITLE
pytest-redis fixture repair

### DIFF
--- a/tests/test_fhir.py
+++ b/tests/test_fhir.py
@@ -43,11 +43,11 @@ def pdmp_med_request_bundle(request):
 
 real_redis_connection = SESSION_REDIS.connection_pool.get_connection('testing-connection')
 redis_factory = factories.redis_noproc(host=real_redis_connection.host)
-redis_db = factories.redisdb('redis_factory')
+redis_handle = factories.redisdb('redis_factory')
 
 
 @fixture
-def redis_session(client, redis_db):
+def redis_session(client, redis_handle):
     """Loads a redis-session with a mock patient id and iss"""
     session_prefix = client.application.config.get(
         'SESSION_KEY_PREFIX', 'session:')
@@ -57,7 +57,7 @@ def redis_session(client, redis_db):
         'token_response': {'patient': patient_id}
     }
 
-    redis_db.set(session_key, pickle.dumps(session_data))
+    redis_handle.set(session_key, pickle.dumps(session_data))
 
 
 def test_emr_med_request(app_w_iss, requests_mock, emr_med_request_bundle):

--- a/tests/test_fhir.py
+++ b/tests/test_fhir.py
@@ -40,7 +40,18 @@ def pdmp_med_request_bundle(request):
     return json_from_file(request, "PDMP-MedicationRequestBundleR4.json")
 
 
-redis_handle = factories.redisdb('redis_nooproc')
+@fixture
+def redis_handle(client):
+    """Returns a redis fixture configured with the current app config"""
+    real_redis = client.application.config.get('SESSION_REDIS')
+    real_redis_connection = real_redis.connection_pool.get_connection('testing-connection')
+
+
+    testing_redis_handle = factories.redis_noproc(
+        host=real_redis_connection.host,
+        port=real_redis_connection.port
+    )
+    return testing_redis_handle
 
 
 @fixture


### PR DESCRIPTION
need to use configured value for `SESSION_REDIS` for CI runs, as the container redis isn't directly accessible at the default 127.0.0.1