### PR TITLE
Reduce terms in dosageInstructions.timing.repeat

### DIFF
--- a/sof_wrapper/api/fhir.py
+++ b/sof_wrapper/api/fhir.py
@@ -37,7 +37,6 @@ def add_cds_extensions(med):
         return med
 
     timing_gcd = gcd(quantity, expected_supply_duration)
-    # TODO: reduce frequency to lowest terms (fractions.gcd), if necessary
     dosage_instruction = [{
         'timing': {
             "repeat": {

--- a/sof_wrapper/api/fhir.py
+++ b/sof_wrapper/api/fhir.py
@@ -20,6 +20,14 @@ def collate_results(*result_sets):
     return results
 
 
+def gcd(a, b):
+    """Find the greatest common divisor between two given floats or integers"""
+    if b == 0:
+        return a
+    else:
+        return gcd(b, a%b)
+
+
 def add_cds_extensions(med):
     """Add FHIR attributes as necessary to support frontend CDS"""
 
@@ -28,12 +36,13 @@ def add_cds_extensions(med):
     if not expected_supply_duration or not quantity:
         return med
 
+    timing_gcd = gcd(quantity, expected_supply_duration)
     # TODO: reduce frequency to lowest terms (fractions.gcd), if necessary
     dosage_instruction = [{
         'timing': {
             "repeat": {
-                "frequency": quantity,
-                "period": expected_supply_duration,
+                "frequency": quantity/timing_gcd,
+                "period": expected_supply_duration/timing_gcd,
                 "periodUnit": "d"
             }
         },

--- a/tests/test_fhir.py
+++ b/tests/test_fhir.py
@@ -193,7 +193,8 @@ def test_dosage_instruction(pdmp_medication_request):
     from sof_wrapper.api import fhir
     annotated_pdmp_med = fhir.add_cds_extensions(pdmp_medication_request)
 
-    assert annotated_pdmp_med['dosageInstruction'][0]['timing']['repeat']['frequency'] == quantity
-    assert annotated_pdmp_med['dosageInstruction'][0]['timing']['repeat']['period'] == supply
+    timing_gcd = fhir.gcd(supply, quantity)
+    assert annotated_pdmp_med['dosageInstruction'][0]['timing']['repeat']['frequency'] == quantity/timing_gcd
+    assert annotated_pdmp_med['dosageInstruction'][0]['timing']['repeat']['period'] == supply/timing_gcd
 
     assert annotated_pdmp_med['dosageInstruction'][0]['doseAndRate'][0]['doseQuantity']['value'] == quantity/supply


### PR DESCRIPTION
Reduce terms in `dosageInstructions.timing.repeat` using greatest common divisor