### PR TITLE
#178668488 SoF backend error reporting API, for front-end to write to 

### DIFF
--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -4,6 +4,8 @@
 #
 #    pip-compile --output-file=requirements.dev.txt
 #
+--requirement requirements.txt
+
 attrs==19.3.0             # via pytest
 filelock==3.0.12          # via tox, virtualenv
 importlib-metadata==1.7.0  # via pluggy, pytest, tox, virtualenv

--- a/sof_wrapper/api/views.py
+++ b/sof_wrapper/api/views.py
@@ -1,4 +1,5 @@
-from flask import Blueprint
+from flask import Blueprint, jsonify, request
+import logging
 
 base_blueprint = Blueprint('base', __name__)
 
@@ -13,3 +14,71 @@ def add_header(response):
     response.headers['Access-Control-Allow-Origin'] = '*'
 
     return response
+
+
+@base_blueprint.route('/auditlog', methods=('OPTIONS', 'POST'))
+def auditlog_addevent():
+    """Add event to audit log
+
+    API for client applications to add any event to the audit log.  The message
+    will land in the same audit log as any auditable internal event, including
+    recording the authenticated user making the call.
+
+    Returns a json friendly message, i.e. {"message": "ok"} or details on error
+    ---
+    operationId: auditlog_addevent
+    tags:
+      - audit
+    produces:
+      - application/json
+    parameters:
+      - in: body
+        name: body
+        schema:
+          id: message
+          required:
+            - message
+          properties:
+            user:
+              type: string
+              description: user identifier, such as email address or ID
+            patient:
+              type: string
+              description: patient identifier (if applicable)
+            level:
+              type: string
+              description: context such as "error", default "info"
+            message:
+              type: string
+              description: message text
+    responses:
+      200:
+        description: successful operation
+        schema:
+          id: response_ok
+          required:
+            - message
+          properties:
+            message:
+              type: string
+              description: Result, typically "ok"
+      401:
+        description: if missing valid OAuth token
+    security:
+      - ServiceToken: []
+
+    """
+    body = request.get_json()
+    if not body:
+        return jsonify(message="Missing JSON data"), 400
+
+    message = body.get('message')
+    level = body.pop('level', 'info')
+    if not hasattr(logging, level.upper()):
+        return jsonify(message="Unknown logging `level`: {level}"), 400
+    if not message:
+        return jsonify(message="missing required 'message' in post"), 400
+
+    log_level_method = getattr(logging, level.lower())
+    log_level_method(body)
+    return jsonify(message='ok')

--- a/tests/test_audit.py
+++ b/tests/test_audit.py
@@ -1,0 +1,33 @@
+def test_auditlog_missing_data(client):
+    response = client.post('/auditlog')
+    # no data, expect 400
+    assert response.status_code == 400
+    assert 'JSON' in response.get_json()['message']
+
+
+def test_auditlog_bogus_level(client):
+    data = {
+        'message': 'something went bump in the night',
+        'level': 'curious'}
+    response = client.post('/auditlog', json=data)
+    assert response.status_code == 400
+    assert 'level' in response.get_json()['message']
+
+
+def test_auditlog_missing_msg(client):
+    data = {'user': 10, 'level': 'debug'}
+    response = client.post('/auditlog', json=data)
+    # no `message`, expect 400
+    assert response.status_code == 400
+    assert 'message' in response.get_json()['message']
+
+
+def test_auditlog_post(client):
+    data = {
+        'user': 'testy@example.com',
+        'patient': 'Jones, Bob; 1969-10-10',
+        'level': 'warning',
+        'message': "No meds!"
+    }
+    response = client.post('/auditlog', json=data)
+    assert response.status_code == 200


### PR DESCRIPTION
Example test call using local deploy and cURL:

```
$  curl --data '{"message": "no problem", "user": "bob@example.com", "level": "debug", "patient": "Cushing, John; 2000-12-10"}' -H "Content-Type: application/json" -X POST http://localtest.me:5000/auditlog
{
  "message": "ok"
}
```

generates the following in the log:
```
sof_wrapper_1  | {"asctime": "2021-06-28 22:29:29,223", "name": "root", "levelname": "DEBUG", "message": "no problem", "user": "bob@example.com", "patient": "Cushing, John; 2000-12-10"}
```