### PR TITLE
API for front-end to save debugging / file info

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,6 +12,7 @@ chardet==3.0.4            # via requests
 click==7.1.2              # via flask
 cryptography==3.0         # via authlib, python-jose
 ecdsa==0.14.1             # via python-jose
+flask-cors==3.0.10        # via sof_wrapper (setup.py)
 flask-session==0.3.2      # via sof_wrapper (setup.py)
 flask==1.1.2              # via flask-session, sof_wrapper (setup.py)
 idna==2.10                # via requests

--- a/setup.cfg
+++ b/setup.cfg
@@ -18,6 +18,7 @@ setup_requires =
 install_requires =
     authlib
     flask
+    flask-cors
     flask-session
     python-jose[cryptography]
     python-json-logger

--- a/sof_wrapper/api/views.py
+++ b/sof_wrapper/api/views.py
@@ -127,7 +127,7 @@ def save_data():
               description: Result, typically "ok"
 
     """
-    if app.config["ENV"] != "development:
+    if current_app.config["ENV"] != "development":
         return jsonify(message="Disabled on non-dev deploys"), 401
     body = request.get_json()
     if not body:

--- a/sof_wrapper/api/views.py
+++ b/sof_wrapper/api/views.py
@@ -127,6 +127,8 @@ def save_data():
               description: Result, typically "ok"
 
     """
+    if app.config["ENV"] != "development:
+        return jsonify(message="Disabled on non-dev deploys"), 401
     body = request.get_json()
     if not body:
         return jsonify(message="Missing JSON data"), 400

--- a/sof_wrapper/api/views.py
+++ b/sof_wrapper/api/views.py
@@ -12,14 +12,7 @@ def root():
     return {'ok': True}
 
 
-@base_blueprint.after_request
-def add_header(response):
-    response.headers['Access-Control-Allow-Origin'] = '*'
-
-    return response
-
-
-@base_blueprint.route('/auditlog', methods=('OPTIONS', 'POST'))
+@base_blueprint.route('/auditlog', methods=('POST',))
 def auditlog_addevent():
     """Add event to audit log
 
@@ -87,7 +80,7 @@ def auditlog_addevent():
     return jsonify(message='ok')
 
 
-@base_blueprint.route('/save_data', methods=('OPTIONS', 'POST'))
+@base_blueprint.route('/save_data', methods=('POST',))
 def save_data():
     """Write JSON to disk
 

--- a/sof_wrapper/api/views.py
+++ b/sof_wrapper/api/views.py
@@ -1,5 +1,8 @@
-from flask import Blueprint, jsonify, request
+from flask import Blueprint, current_app, jsonify, request
+import json
 import logging
+import os
+import uuid
 
 base_blueprint = Blueprint('base', __name__)
 
@@ -82,3 +85,81 @@ def auditlog_addevent():
     log_level_method = getattr(logging, level.lower())
     log_level_method(body)
     return jsonify(message='ok')
+
+
+@base_blueprint.route('/save_data', methods=('OPTIONS', 'POST'))
+def save_data():
+    """Write JSON to disk
+
+    API for client applications to write JSON directly to disk.
+    Intended use: front-end can capture data at any point and write
+    to disk for testing & verification.
+
+    Returns a json friendly message, i.e. {"message": "ok"} or details on error
+    ---
+    operationId: save_data
+    tags:
+      - debugging
+    produces:
+      - application/json
+    parameters:
+      - in: body
+        name: body
+        schema:
+          id: save_data
+          required:
+            - context
+            - data
+          properties:
+            filename:
+              type: string
+              description: string to save file as.  UUID used by default.
+                does not allow overwrites.
+            context:
+              type: string
+              description: context such as "CQL MME calc"
+            data:
+              type: json
+              description: json serialized data to capture
+    responses:
+      200:
+        description: successful operation
+        schema:
+          id: response_ok
+          required:
+            - message
+          properties:
+            message:
+              type: string
+              description: Result, typically "ok"
+
+    """
+    body = request.get_json()
+    if not body:
+        return jsonify(message="Missing JSON data"), 400
+
+    data = body.get('data', None)
+    context = body.get('context', None)
+    for item in ('data', 'context'):
+        if not locals()[item]:
+            return jsonify(
+                message=f"missing required '{item}' in post"), 400
+
+    filename = body.get('filename', str(uuid.uuid4()))
+    location = current_app.config['DEBUG_OUTPUT_DIR']
+    if not (os.path.isdir(location)):
+        return jsonify(
+            message="ill configured, can't find DEBUG_OUTPUT_DIR"), 400
+    full_path = os.path.join(location, filename)
+    if os.path.dirname(full_path) != location:
+        return jsonify(
+            message="no path info allowed in `filename` parameter"), 400
+
+    if os.path.exists(full_path):
+        return jsonify(
+            message=f"file '{filename}' exists, won't overwrite"), 400
+
+    with open(full_path, 'w') as fp:
+        json.dump(body, fp, indent=4)
+
+    return jsonify(message='ok', saved_file=full_path)

--- a/sof_wrapper/app.py
+++ b/sof_wrapper/app.py
@@ -1,4 +1,5 @@
 from flask import Flask
+from flask_cors import CORS
 from logging import config as logging_config
 import os
 from werkzeug.middleware.proxy_fix import ProxyFix
@@ -13,6 +14,7 @@ def create_app(testing=False, cli=False):
     app = Flask('sof_wrapper')
     app.config.from_object('sof_wrapper.config')
     app.config['TESTING'] = testing
+    CORS(app)
 
     configure_logging(app)
     configure_extensions(app, cli)

--- a/sof_wrapper/auth/views.py
+++ b/sof_wrapper/auth/views.py
@@ -214,10 +214,4 @@ def before_request_func():
 def after_request_func(response):
     current_app.logger.debug('after_request session: %s', session)
     current_app.logger.debug('after_request authlib state present: %s','_sof_authlib_state_' in session)
-
-    # todo: make configurable
-    origin = request.headers.get('Origin', '*')
-    response.headers['Access-Control-Allow-Origin'] = origin
-    response.headers['Access-Control-Allow-Credentials'] = 'true'
-
     return response

--- a/sof_wrapper/config.py
+++ b/sof_wrapper/config.py
@@ -5,6 +5,7 @@ Use env var to override
 import os
 import redis
 
+DEBUG_OUTPUT_DIR = os.getenv("DEBUG_OUTPUT_DIR", '/tmp')
 SERVER_NAME = os.getenv("SERVER_NAME")
 SECRET_KEY = os.getenv("SECRET_KEY")
 # URL scheme to use outside of request context


### PR DESCRIPTION
As per chat/request in needing to save data from the front-end, for data validation, a new API enables persisting nearly any JSON to the filesystem, at `/save_data`

Persists the entire structure POSTed, but does require at least two top level attributes:
- context
- data

Our hand rolled CORS management continues to fail for views supporting POST.  I expect this has to do with improper handling of the pre-flight OPTIONS request, but rather than continue with the tedium of getting that right, opted to replace with `flask-cors` (and eliminated the partial solution in two blueprint @after_request views).

Useful CURL invocation to test:
```
curl -H "Origin: http://example.com" --verbose \
  -H "Access-Control-Request-Method: POST" \
  -H "Access-Control-Request-Headers: X-Requested-With" \
  -X OPTIONS  \
  <system-under-test-url>/save_data
```