### PR TITLE
Overwrite save file with matching filename

### DIFF
--- a/sof_wrapper/api/views.py
+++ b/sof_wrapper/api/views.py
@@ -151,8 +151,7 @@ def save_data():
             message="no path info allowed in `filename` parameter"), 400
 
     if os.path.exists(full_path):
-        return jsonify(
-            message=f"file '{filename}' exists, won't overwrite"), 400
+        pass  # overwrite by design on subsequent request
 
     with open(full_path, 'w') as fp:
         json.dump(body, fp, indent=4)


### PR DESCRIPTION
As we frequently reprocess the same patient and name save files by patient, intentionally allow overwrite.

ATM, 400 is raised when configured to save_data and same patient is viewed 2x.