### PR TITLE
Add utility to abort from json view including content-type headers

### DIFF
--- a/sof_wrapper/api/fhir.py
+++ b/sof_wrapper/api/fhir.py
@@ -1,8 +1,9 @@
 import pickle
 import requests
 
-from flask import Blueprint, abort, current_app, request, session, g
+from flask import Blueprint, current_app, request, session, g
 
+from sof_wrapper.jsonify_abort import jsonify_abort
 from sof_wrapper.rxnav import add_drug_classes
 
 blueprint = Blueprint('fhir', __name__)
@@ -241,11 +242,11 @@ def route_fhir(relative_path, session_id):
     # prefer patient ID baked into access token JWT by EHR; fallback to initial transparent launch token for fEMR
     patient_id = session_data.get('token_response', {}).get('patient') or session_data.get('launch_token_patient')
     if not patient_id:
-        abort(400, "no patient ID found in session; can't continue")
+        jsonify_abort(status_code=400, message="no patient ID found in session; can't continue")
 
     iss = session_data.get('iss')
     if not iss:
-        abort(400, "no iss found in session; can't continue")
+        jsonify_abort(status_code=400, message="no iss found in session; can't continue")
 
     paths = relative_path.split('/')
     resource_name = paths.pop()

--- a/sof_wrapper/jsonify_abort.py
+++ b/sof_wrapper/jsonify_abort.py
@@ -1,0 +1,8 @@
+"""Utility function to bring together flask `abort` and `jsonify`"""
+from flask import abort, jsonify, make_response
+
+def jsonify_abort(status_code, **kwargs):
+    """Takes any number of args, like jsonify, but raises like abort with correct content_type heading"""
+    response = make_response(jsonify(kwargs))
+    response.status_code = status_code
+    abort(response)


### PR DESCRIPTION
Reuse lessons learned from https://github.com/uwcirg/cosri-patientsearch/pull/49 - add `jsonify_abort()` to include correct content-type headers when aborting from JSON views.