### PR TITLE
Submit user's DEA on PDMP requests.

### DIFF
--- a/sof_wrapper/api/fhir.py
+++ b/sof_wrapper/api/fhir.py
@@ -89,7 +89,7 @@ def pdmp_med_requests(**kwargs):
     params = kwargs or dict(request.args)
     user = session.get('user') or get_redis_session_data(g.session_id).get('user')
     if not user or 'DEA' not in user:
-        jsonify_abort(status_code=400, message=f"DEA not found")
+        jsonify_abort(status_code=400, message="DEA not found")
     params['DEA'] = user['DEA']
     return pdmp_meds(pdmp_url, params)
 

--- a/sof_wrapper/api/fhir.py
+++ b/sof_wrapper/api/fhir.py
@@ -111,7 +111,7 @@ def pdmp_med_orders(**kwargs):
     params = kwargs or request.args
     user = session.get('user') or get_redis_session_data(g.session_id).get('user')
     if not user or 'DEA' not in user:
-        jsonify_abort(status_code=400, message=f"DEA not found")
+        jsonify_abort(status_code=400, message="DEA not found")
     params['DEA'] = user['DEA']
     return pdmp_meds(pdmp_url, params)
 

--- a/sof_wrapper/api/fhir.py
+++ b/sof_wrapper/api/fhir.py
@@ -86,7 +86,7 @@ def pdmp_med_requests(**kwargs):
     pdmp_url = '{base_url}/v/r4/fhir/MedicationOrder'.format(
         base_url=current_app.config['PDMP_URL'],
     )
-    params = kwargs or request.args
+    params = kwargs or dict(request.args)
     user = session.get('user') or get_redis_session_data(g.session_id).get('user')
     if not user or 'DEA' not in user:
         jsonify_abort(status_code=400, message=f"DEA not found")

--- a/sof_wrapper/auth/views.py
+++ b/sof_wrapper/auth/views.py
@@ -153,10 +153,20 @@ def authorize():
     # todo: define fetch_token function that requests JSON (Accept: application/json header)
     # https://github.com/lepture/authlib/blob/master/authlib/oauth2/client.py#L154
     token_response = oauth.sof.authorize_access_token(_format='json')
-    user = extract_payload(token_response.get('id_token')).get('profile', '')
     extra = {}
-    if user:
-        extra['user'] = user
+    extracted_id_token = extract_payload(token_response.get('id_token'))
+    username = extracted_id_token.get('preferred_username')
+    DEA = extracted_id_token.get('DEA')
+
+    # standalone uses profile
+    if 'profile' in extracted_id_token:
+        extra['user'] = extracted_id_token['profile']
+    else:
+        extra['user'] = {'username': username, 'DEA': DEA}
+
+    # retain extracted user details in session, as needed elsewhere
+    session['user'] = extra['user']
+
     if 'patient' in token_response:
         extra['subject'] = 'Patient/{}'.format(token_response['patient'])
     current_app.logger.info("login", extra=extra)

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -24,6 +24,11 @@ def example_token():
         'qQ'))
 
 
+@fixture
+def jwt_sample():
+    return "eyJhbGciOiJSUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJfcW5PSE1xeDhidGpldW1CQUVvNjBaQVJoWThxd2Y0WU1ncU1GOEZreHNFIn0.eyJqdGkiOiI4ZGZmMmNiNy1hODUzLTQ4ZWEtOGZjMS01M2ZkMzVjZDEwMGQiLCJleHAiOjE2MzA3MTYwMDksIm5iZiI6MCwiaWF0IjoxNjMwNzE0MjA5LCJpc3MiOiJodHRwczovL2tleWNsb2FrLnBiLmRldi5jb3NyaS5jaXJnLndhc2hpbmd0b24uZWR1L2F1dGgvcmVhbG1zL2ZFTVIiLCJhdWQiOiJhY2NvdW50Iiwic3ViIjoiNzk0ZDI3ODItZTc4My00Y2JiLWFlNzItYjE2NWE0YzA2ZTdmIiwidHlwIjoiQmVhcmVyIiwiYXpwIjoiY29zcmlfb3BlbmlkX2NsaWVudCIsImF1dGhfdGltZSI6MTYzMDcxNDE2Miwic2Vzc2lvbl9zdGF0ZSI6ImI5NzRhZDE1LTg4ZWYtNDFhNi04OGIzLTE1Njk0N2JjZjViOCIsImFjciI6IjAiLCJhbGxvd2VkLW9yaWdpbnMiOlsiKiJdLCJyZWFsbV9hY2Nlc3MiOnsicm9sZXMiOlsib2ZmbGluZV9hY2Nlc3MiLCJ1bWFfYXV0aG9yaXphdGlvbiJdfSwicmVzb3VyY2VfYWNjZXNzIjp7ImFjY291bnQiOnsicm9sZXMiOlsibWFuYWdlLWFjY291bnQiLCJtYW5hZ2UtYWNjb3VudC1saW5rcyIsInZpZXctcHJvZmlsZSJdfX0sInNjb3BlIjoib3BlbmlkIHByb2ZpbGUgZW1haWwiLCJERUEiOiJ0ZXN0REVBdmFsdWUiLCJlbWFpbF92ZXJpZmllZCI6ZmFsc2UsInByZWZlcnJlZF91c2VybmFtZSI6InRlc3QifQ.A5LFRH-obxsGov1RMorpY0UFQHiMjL5nbl5oS5fMSPOiE9KG1MdzlIr_5GG4LkBj3G6598rPi6-oPE5A4eM6ZT3wczyglFmW3RbaPfVxAA9zD0wDv77nnPjnFalr54VJdhDIZMn7jRIPSMtFvPq3dO-y6qHaJtwzVlefp1GUwiaZclb4JyMkIc5EMc1fZsvw87PNotNhNlAQpo64Ht8_35RNYOTmtE0W-xUBn-rtXaHE9BSoyZj3pB3AX4sk6PYSE7eIB3ZQnTMCVvYz9o-KQf6WPmSJfyvvFk8EpDoyHSV6yeVDTyHayUf9KfQk6vfogzGLHTOri9ur_1hlI0GYug"
+
+
 def test_extract(example_token):
     extracted = extract_payload(example_token)
     assert 'profile' in extracted
@@ -40,3 +45,8 @@ def test_bad_extract():
     jwt = format_as_jwt('ill formed string')
     assert len(jwt.split('.')) == 3
     assert extract_payload(jwt) == {}
+
+
+def test_dea_extract(jwt_sample):
+    results = extract_payload(jwt_sample)
+    assert results['DEA'] == 'testDEAvalue'

--- a/tests/test_fhir.py
+++ b/tests/test_fhir.py
@@ -134,6 +134,9 @@ def test_pdmp_med_request(client, requests_mock, pdmp_med_request_bundle):
     client.application.config['PDMP_URL'] = pdmp_url
     pdmp_api = f"{pdmp_url}/v/r4/fhir/MedicationOrder"
 
+    with client.session_transaction() as session:
+        session['user'] = {"username": "unittest", "DEA": "ABC123"}
+
     # mock PDMP MedicationRequest
     requests_mock.get(pdmp_api, json=pdmp_med_request_bundle)
 


### PR DESCRIPTION
- Extract DEA and userinfo from JWT into session on /launch
- Submit DEA with PDMP requests
- Include userinfo in audit log entries.
