### PR TITLE
Do not require DEA for Demo

### DIFF
--- a/sof_wrapper/api/fhir.py
+++ b/sof_wrapper/api/fhir.py
@@ -89,7 +89,6 @@ def pdmp_med_requests(**kwargs):
     # decoded JWT, or FHIR Practioner reference (eg Practitioner/ID)
     user = get_session_value('user')
 
-    # in a demo deploy, SCRIPT_ENDPOINT_URL will be configured, but empty
     if user and "DEA" in user:
         DEA = user["DEA"]
     # in a demo deploy, SCRIPT_ENDPOINT_URL will be configured, but empty

--- a/sof_wrapper/api/fhir.py
+++ b/sof_wrapper/api/fhir.py
@@ -70,6 +70,20 @@ def emr_med_orders(patient_id):
     return emr_meds(emr_url, params, request.headers)
 
 
+def get_dea(user):
+    """
+    Look up current user's DEA from their decoded access token JWT
+    if configured as demo, return dummy value
+    """
+    if user and "DEA" in user:
+        return user["DEA"]
+
+    # in a demo deploy, SCRIPT_ENDPOINT_URL will be configured, but empty
+    if current_app.config.get("SCRIPT_ENDPOINT_URL") == "":
+        return "FAKEDEA123"
+
+    return None
+
 @blueprint.route(f'{r4prefix}/pdmp/MedicationRequest')
 def pdmp_med_requests(**kwargs):
     """return results from PDMP request for MedicationRequest
@@ -88,15 +102,11 @@ def pdmp_med_requests(**kwargs):
     # decoded JWT, or FHIR Practioner reference (eg Practitioner/ID)
     user = get_session_value('user')
 
-    if user and "DEA" in user:
-        DEA = user["DEA"]
-    # in a demo deploy, SCRIPT_ENDPOINT_URL will be configured, but empty
-    elif current_app.config.get("SCRIPT_ENDPOINT_URL") == "":
-        DEA = "FAKEDEA123"
-    else:
+    DEA = get_dea(user)
+    if not DEA:
         return jsonify_abort(status_code=400, message="DEA not found")
-
     params['DEA'] = DEA
+
     return pdmp_meds(pdmp_url, params)
 
 
@@ -118,15 +128,11 @@ def pdmp_med_orders(**kwargs):
     # decoded JWT, or FHIR Practioner reference (eg Practitioner/ID)
     user = get_session_value('user')
 
-    if user and "DEA" in user:
-        DEA = user["DEA"]
-    # in a demo deploy, SCRIPT_ENDPOINT_URL will be configured, but empty
-    elif current_app.config.get("SCRIPT_ENDPOINT_URL") == "":
-        DEA = "FAKEDEA123"
-    else:
+    DEA = get_dea(user)
+    if not DEA:
         return jsonify_abort(status_code=400, message="DEA not found")
-
     params['DEA'] = DEA
+
     return pdmp_meds(pdmp_url, params)
 
 

--- a/sof_wrapper/api/fhir.py
+++ b/sof_wrapper/api/fhir.py
@@ -86,7 +86,7 @@ def pdmp_med_requests(**kwargs):
         base_url=current_app.config['PDMP_URL'],
     )
     params = kwargs or dict(request.args)
-    user = get_session_value('user')
+    user = get_session_value('user') or {}
 
     # in a demo deploy, SCRIPT_ENDPOINT_URL will be configured, but empty
     if current_app.config.get("SCRIPT_ENDPOINT_URL") == "":
@@ -112,12 +112,12 @@ def pdmp_med_orders(**kwargs):
         base_url=current_app.config['PDMP_URL'],
         )
     params = kwargs or request.args
-    user = get_session_value('user')
+    user = get_session_value('user') or {}
 
     # in a demo deploy, SCRIPT_ENDPOINT_URL will be configured, but empty
     if current_app.config.get("SCRIPT_ENDPOINT_URL") == "":
         user['DEA'] = "FAKEDEA123"
-    elif not user or 'DEA' not in user:
+    if not user or 'DEA' not in user:
         return jsonify_abort(status_code=400, message="DEA not found")
     params['DEA'] = user['DEA']
     return pdmp_meds(pdmp_url, params)

--- a/sof_wrapper/api/fhir.py
+++ b/sof_wrapper/api/fhir.py
@@ -86,14 +86,15 @@ def pdmp_med_requests(**kwargs):
         base_url=current_app.config['PDMP_URL'],
     )
     params = kwargs or dict(request.args)
-    user = get_session_value('user') or {}
+    # decoded JWT, or FHIR Practioner reference (eg Practitioner/ID)
+    user = get_session_value('user')
 
     # in a demo deploy, SCRIPT_ENDPOINT_URL will be configured, but empty
     if current_app.config.get("SCRIPT_ENDPOINT_URL") == "":
-        user['DEA'] = "FAKEDEA123"
+        DEA = "FAKEDEA123"
     elif not user or 'DEA' not in user:
         return jsonify_abort(status_code=400, message="DEA not found")
-    params['DEA'] = user['DEA']
+    params['DEA'] = DEA
     return pdmp_meds(pdmp_url, params)
 
 
@@ -112,14 +113,15 @@ def pdmp_med_orders(**kwargs):
         base_url=current_app.config['PDMP_URL'],
         )
     params = kwargs or request.args
-    user = get_session_value('user') or {}
+    # decoded JWT, or FHIR Practioner reference (eg Practitioner/ID)
+    user = get_session_value('user')
 
     # in a demo deploy, SCRIPT_ENDPOINT_URL will be configured, but empty
     if current_app.config.get("SCRIPT_ENDPOINT_URL") == "":
-        user['DEA'] = "FAKEDEA123"
+        DEA = "FAKEDEA123"
     if not user or 'DEA' not in user:
         return jsonify_abort(status_code=400, message="DEA not found")
-    params['DEA'] = user['DEA']
+    params['DEA'] = DEA
     return pdmp_meds(pdmp_url, params)
 
 

--- a/sof_wrapper/api/fhir.py
+++ b/sof_wrapper/api/fhir.py
@@ -90,10 +90,14 @@ def pdmp_med_requests(**kwargs):
     user = get_session_value('user')
 
     # in a demo deploy, SCRIPT_ENDPOINT_URL will be configured, but empty
-    if current_app.config.get("SCRIPT_ENDPOINT_URL") == "":
+    if user and "DEA" in user:
+        DEA = user["DEA"]
+    # in a demo deploy, SCRIPT_ENDPOINT_URL will be configured, but empty
+    elif current_app.config.get("SCRIPT_ENDPOINT_URL") == "":
         DEA = "FAKEDEA123"
-    elif not user or 'DEA' not in user:
+    else:
         return jsonify_abort(status_code=400, message="DEA not found")
+
     params['DEA'] = DEA
     return pdmp_meds(pdmp_url, params)
 
@@ -116,11 +120,14 @@ def pdmp_med_orders(**kwargs):
     # decoded JWT, or FHIR Practioner reference (eg Practitioner/ID)
     user = get_session_value('user')
 
+    if user and "DEA" in user:
+        DEA = user["DEA"]
     # in a demo deploy, SCRIPT_ENDPOINT_URL will be configured, but empty
-    if current_app.config.get("SCRIPT_ENDPOINT_URL") == "":
+    elif current_app.config.get("SCRIPT_ENDPOINT_URL") == "":
         DEA = "FAKEDEA123"
-    if not user or 'DEA' not in user:
+    else:
         return jsonify_abort(status_code=400, message="DEA not found")
+
     params['DEA'] = DEA
     return pdmp_meds(pdmp_url, params)
 

--- a/sof_wrapper/api/fhir.py
+++ b/sof_wrapper/api/fhir.py
@@ -35,25 +35,6 @@ def annotate_meds(med_bundle):
     return annotated_bundle
 
 
-@blueprint.route(f'{r4prefix}/emr/MedicationRequest', defaults={'patient_id': None})
-@blueprint.route(f'{r4prefix}/emr/MedicationRequest/<string:patient_id>')
-def emr_med_requests(patient_id):
-    base_url = get_session_value('iss')
-    emr_url = f'{base_url}/MedicationRequest'
-    params = {"subject": f"Patient/{patient_id}"} if patient_id else {}
-    return emr_meds(emr_url, params, request.headers)
-
-
-@blueprint.route(f'{r2prefix}/emr/MedicationOrder', defaults={'patient_id': None})
-@blueprint.route(f'{r2prefix}/emr/MedicationOrder/<string:patient_id>')
-def emr_med_orders(patient_id):
-    base_url = get_session_value('iss')
-    emr_url = f'{base_url}/MedicationOrder'
-    params = {"patient": f"Patient/{patient_id}"} if patient_id else {}
-
-    return emr_meds(emr_url, params, request.headers)
-
-
 def emr_meds(emr_url, params, headers):
     upstream_headers = {}
     for header_name in PROXY_HEADERS:
@@ -69,6 +50,24 @@ def emr_meds(emr_url, params, headers):
     current_app.logger.debug("emr returned {} MedicationRequests".format(
         len(response.json().get("entry", []))))
     return response.json()
+
+
+@blueprint.route(f'{r4prefix}/emr/MedicationRequest', defaults={'patient_id': None})
+@blueprint.route(f'{r4prefix}/emr/MedicationRequest/<string:patient_id>')
+def emr_med_requests(patient_id):
+    base_url = get_session_value('iss')
+    emr_url = f'{base_url}/MedicationRequest'
+    params = {"subject": f"Patient/{patient_id}"} if patient_id else {}
+    return emr_meds(emr_url, params, request.headers)
+
+
+@blueprint.route(f'{r2prefix}/emr/MedicationOrder', defaults={'patient_id': None})
+@blueprint.route(f'{r2prefix}/emr/MedicationOrder/<string:patient_id>')
+def emr_med_orders(patient_id):
+    base_url = get_session_value('iss')
+    emr_url = f'{base_url}/MedicationOrder'
+    params = {"patient": f"Patient/{patient_id}"} if patient_id else {}
+    return emr_meds(emr_url, params, request.headers)
 
 
 @blueprint.route(f'{r4prefix}/pdmp/MedicationRequest')

--- a/sof_wrapper/api/fhir.py
+++ b/sof_wrapper/api/fhir.py
@@ -87,7 +87,11 @@ def pdmp_med_requests(**kwargs):
     )
     params = kwargs or dict(request.args)
     user = get_session_value('user')
-    if not user or 'DEA' not in user:
+
+    # in a demo deploy, SCRIPT_ENDPOINT_URL will be configured, but empty
+    if current_app.config.get("SCRIPT_ENDPOINT_URL") == "":
+        user['DEA'] = "FAKEDEA123"
+    elif not user or 'DEA' not in user:
         return jsonify_abort(status_code=400, message="DEA not found")
     params['DEA'] = user['DEA']
     return pdmp_meds(pdmp_url, params)
@@ -109,7 +113,11 @@ def pdmp_med_orders(**kwargs):
         )
     params = kwargs or request.args
     user = get_session_value('user')
-    if not user or 'DEA' not in user:
+
+    # in a demo deploy, SCRIPT_ENDPOINT_URL will be configured, but empty
+    if current_app.config.get("SCRIPT_ENDPOINT_URL") == "":
+        user['DEA'] = "FAKEDEA123"
+    elif not user or 'DEA' not in user:
         return jsonify_abort(status_code=400, message="DEA not found")
     params['DEA'] = user['DEA']
     return pdmp_meds(pdmp_url, params)

--- a/sof_wrapper/config.py
+++ b/sof_wrapper/config.py
@@ -33,6 +33,9 @@ LOG_LEVEL = os.environ.get('LOG_LEVEL', 'DEBUG').upper()
 LAUNCH_DEST = os.getenv("LAUNCH_DEST")
 
 PDMP_URL = os.getenv("PDMP_URL")
+# TODO use better indicator
+# use an empty string to indicate demo deploy
+SCRIPT_ENDPOINT_URL = os.getenv("SCRIPT_ENDPOINT_URL")
 
 PHR_URL = os.getenv("PHR_URL")
 PHR_TOKEN = os.getenv("PHR_TOKEN")


### PR DESCRIPTION
- Set default DEA number when configured as demo
- Use the same env var (`SCRIPT_ENDPOINT_URL`) as the PDMP facade to detect demo environment