### PR TITLE
Updated elgohr/Publish-Docker-Github-Action to a supported version (v5)

### DIFF
--- a/.github/workflows/build-deliver.yaml
+++ b/.github/workflows/build-deliver.yaml
@@ -19,7 +19,7 @@ jobs:
 
       - name: Publish to Dockerhub registry
         # todo: pin to hash
-        uses: elgohr/Publish-Docker-Github-Action@master
+        uses: elgohr/Publish-Docker-Github-Action@v5
         with:
           # https://help.github.com/en/actions/reference/context-and-expression-syntax-for-github-actions
           name: ${{ github.repository }}


### PR DESCRIPTION
elgohr/Publish-Docker-Github-Action@master is not supported anymore