### PR TITLE
add DELETE for allowed FHIR API method

### DIFF
--- a/sof_wrapper/api/fhir.py
+++ b/sof_wrapper/api/fhir.py
@@ -299,6 +299,6 @@ def route_fhir(relative_path, session_id):
 def add_header(response):
     response.headers['Access-Control-Allow-Origin'] = '*'
     response.headers['Access-Control-Allow-Headers'] = 'Authorization, Cache-Control, Content-Type'
-    response.headers['Access-Control-Allow-Methods'] = 'GET, OPTIONS, POST, PUT'
+    response.headers['Access-Control-Allow-Methods'] = 'GET, OPTIONS, POST, PUT, DELETE'
 
     return response


### PR DESCRIPTION
context: see [Slack convo](https://cirg.slack.com/archives/C01P9V67NMA/p1747969340597569?thread_ts=1747946893.455069&cid=C01P9V67NMA)
To allow clearing resources on the UI for testing purpose (see example UI)

![Screenshot 2025-05-28 at 10 10 42 AM](https://github.com/user-attachments/assets/08bd18cb-69a0-40b5-834a-f8c8a975879c)


current issue: CORS error when API call with DELETE method is made from the frontend:
![Screenshot 2025-05-27 at 9 20 13 AM (1)](https://github.com/user-attachments/assets/e9935c48-f1b8-447f-aaf6-537c01f906db)

see [COSRI shared dev instance](https://dashboard.acc.dev.cosri.cirg.washington.edu/), patient `Darth TestPatient`