### PR TITLE
Revert PDMP Rx Audit Logging

### DIFF
--- a/sof_wrapper/api/fhir.py
+++ b/sof_wrapper/api/fhir.py
@@ -149,7 +149,7 @@ def pdmp_meds(pdmp_url, params):
             len(response.json().get("entry", [])),
             response.elapsed.total_seconds(),
         ),
-        extra={'tags': ['PDMP', 'MedicationRequest']}
+        extra={'tags': ['PDMP', 'MedicationRequest'], 'meds': [e for e in response.json().get("entry", [])]}
     )
     return response.json()
 


### PR DESCRIPTION
Revert "Fixup FHIR compliance; add missing `resource` nesting (#76)"

This reverts commit d829f5dab70473e6fd7424f48e005f5c3784336a.

Log all PDMP drugs in full detail to audit log